### PR TITLE
- fixed an issue, when placeholder text overlapped cursor after clearing...

### DIFF
--- a/Classes/SZTextView.m
+++ b/Classes/SZTextView.m
@@ -110,6 +110,7 @@ static float kUITextViewPadding = 8.0;
 {
     if (self.text.length < 1) {
         [self addSubview:self._placeholderLabel];
+        [self sendSubviewToBack: self._placeholderLabel];
     } else {
         [self._placeholderLabel removeFromSuperview];
     }


### PR DESCRIPTION
The placeholder label overlapped the cursor, as shown in first screen

![IMG_0014](https://f.cloud.github.com/assets/1830010/361660/2ec07b8e-a1cc-11e2-9d90-4eba5c6696b8.PNG)
![IMG_0015](https://f.cloud.github.com/assets/1830010/361661/2ed86a82-a1cc-11e2-9a90-549594459d17.PNG)
