### PR TITLE
Placeholder with exclusion paths

### DIFF
--- a/Classes/SZTextView.m
+++ b/Classes/SZTextView.m
@@ -191,6 +191,7 @@ static float kUITextViewPadding = 8.0;
     [self removeObserver:self forKeyPath:kPlaceholderKey];
     [self removeObserver:self forKeyPath:kFontKey];
     [self removeObserver:self forKeyPath:kTextKey];
+    [self.textContainer removeObserver:self forKeyPath:kExclusionPaths];
 }
 
 @end


### PR DESCRIPTION
I change the place holder to be a UITextView so it can use new methods for iOS 7 as exclusionPaths. This PR adds the use of the same exclusionPath for the placeholder as the one from the SZTextView
