### PR TITLE
SZTextView placeholder text view ignores custom `textContainerInset` value set before `awakeFromNib`

### DIFF
--- a/Classes/SZTextView.m
+++ b/Classes/SZTextView.m
@@ -58,6 +58,10 @@ static NSString * const kTextContainerInsetKey = @"textContainerInset";
     if (HAS_TEXT_CONTAINER) {
         self._placeholderTextView.textContainer.exclusionPaths = self.textContainer.exclusionPaths;
     }
+    
+    if (HAS_TEXT_CONTAINER_INSETS(self)) {
+        self._placeholderTextView.textContainerInset = self.textContainerInset;
+    }
 
     if (_placeholder) {
         self._placeholderTextView.text = _placeholder;


### PR DESCRIPTION
In some circumstances (notable example: in `awakeFromNib` method of `UITableViewCell` loaded from nib, which contains an SZTextView), `textContainerInset` property may be changed on a text view between `initWithCoder` and `awakeFromNib` calls. `exclusionPaths` property, for example, is already processed in this case, but `textContainerInset` is not, thus this inset becomes "out-of-sync" between the "real" text view and placeholder text view. A solution is to set the current value on placeholder text view in `awakeFromNib`.
