### PR TITLE
Add support for matching lineFragmentPadding

### DIFF
--- a/Classes/SZTextView.m
+++ b/Classes/SZTextView.m
@@ -58,9 +58,9 @@ static NSString * const kTextContainerInsetKey = @"textContainerInset";
 
     if (HAS_TEXT_CONTAINER) {
         self._placeholderTextView.textContainer.exclusionPaths = self.textContainer.exclusionPaths;
-		self._placeholderTextView.textContainer.lineFragmentPadding = self.textContainer.lineFragmentPadding;
-	}
-    
+        self._placeholderTextView.textContainer.lineFragmentPadding = self.textContainer.lineFragmentPadding;
+    }
+
     if (HAS_TEXT_CONTAINER_INSETS(self)) {
         self._placeholderTextView.textContainerInset = self.textContainerInset;
     }
@@ -93,7 +93,7 @@ static NSString * const kTextContainerInsetKey = @"textContainerInset";
                                 options:NSKeyValueObservingOptionNew context:nil];
     }
 
-	if (HAS_TEXT_CONTAINER_INSETS(self)) {
+    if (HAS_TEXT_CONTAINER_INSETS(self)) {
         [self addObserver:self forKeyPath:kTextContainerInsetKey
                   options:NSKeyValueObservingOptionNew context:nil];
     }
@@ -177,7 +177,7 @@ static NSString * const kTextContainerInsetKey = @"textContainerInset";
 
     if (HAS_TEXT_CONTAINER) {
         [self.textContainer removeObserver:self forKeyPath:kExclusionPathsKey];
-		[self.textContainer removeObserver:self forKeyPath:kLineFragmentPaddingKey];
+        [self.textContainer removeObserver:self forKeyPath:kLineFragmentPaddingKey];
     }
 
     if (HAS_TEXT_CONTAINER_INSETS(self)) {
@@ -186,4 +186,3 @@ static NSString * const kTextContainerInsetKey = @"textContainerInset";
 }
 
 @end
-


### PR DESCRIPTION
Simply adds tracking of self.textContainer.lineFragmentPadding. Line fragment padding defaults to 10.0 but in our app we set it to 0. This made our placeholder offset from our normal text by that 10 pixels. Tracking lineFragmentPadding of course fixes this.
