### PR TITLE
allow configuring SZTextView in storyboard

### DIFF
--- a/Classes/SZTextView.m
+++ b/Classes/SZTextView.m
@@ -26,17 +26,24 @@ static NSString * const kTextContainerInsetKey = @"textContainerInset";
 
 @implementation SZTextView
 
-- (id)initWithFrame:(CGRect)frame
-{
-    self = [super initWithFrame:frame];
+- (instancetype)initWithCoder:(NSCoder *)coder {
+    self = [super initWithCoder:coder];
     if (self) {
-        [self awakeFromNib];
+        [self preparePlaceholder];
     }
     return self;
 }
 
-- (void)awakeFromNib
-{
+- (id)initWithFrame:(CGRect)frame {
+    self = [super initWithFrame:frame];
+    if (self) {
+        [self preparePlaceholder];
+    }
+    return self;
+}
+
+- (void)preparePlaceholder {
+    NSAssert(!self._placeholderTextView, @"placeholder has been prepared already: %@", self._placeholderTextView);
     // the label which displays the placeholder
     // needs to inherit some properties from its parent text view
 

--- a/Demo/SZTextView.xcodeproj/project.pbxproj
+++ b/Demo/SZTextView.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4B737CB6197B1A67006F3493 /* SZTextViewStoryboardTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4B737CB5197B1A67006F3493 /* SZTextViewStoryboardTests.m */; };
 		5B8D20BB16F1717100D92F51 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B8D20BA16F1717100D92F51 /* UIKit.framework */; };
 		5B8D20BD16F1717100D92F51 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B8D20BC16F1717100D92F51 /* Foundation.framework */; };
 		5B8D20BF16F1717100D92F51 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B8D20BE16F1717100D92F51 /* CoreGraphics.framework */; };
@@ -36,6 +37,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		4B737CB5197B1A67006F3493 /* SZTextViewStoryboardTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SZTextViewStoryboardTests.m; sourceTree = "<group>"; };
 		5B8D20B716F1717100D92F51 /* SZTextView.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SZTextView.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5B8D20BA16F1717100D92F51 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		5B8D20BC16F1717100D92F51 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -148,6 +150,7 @@
 			children = (
 				5B8D20EA16F1717200D92F51 /* SZTextViewTests.h */,
 				5B8D20EB16F1717200D92F51 /* SZTextViewTests.m */,
+				4B737CB5197B1A67006F3493 /* SZTextViewStoryboardTests.m */,
 				5B8D20E516F1717200D92F51 /* Supporting Files */,
 			);
 			name = SZTextViewTests;
@@ -287,6 +290,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5B8D20EC16F1717200D92F51 /* SZTextViewTests.m in Sources */,
+				4B737CB6197B1A67006F3493 /* SZTextViewStoryboardTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Demo/SZTextView.xcodeproj/xcshareddata/xcschemes/SZTextView.xcscheme
+++ b/Demo/SZTextView.xcodeproj/xcshareddata/xcschemes/SZTextView.xcscheme
@@ -29,7 +29,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "5B8D20DC16F1717200D92F51"
-               BuildableName = "SZTextViewTests.octest"
+               BuildableName = "SZTextViewTests.xctest"
                BlueprintName = "SZTextViewTests"
                ReferencedContainer = "container:SZTextView.xcodeproj">
             </BuildableReference>
@@ -47,7 +47,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "5B8D20DC16F1717200D92F51"
-               BuildableName = "SZTextViewTests.octest"
+               BuildableName = "SZTextViewTests.xctest"
                BlueprintName = "SZTextViewTests"
                ReferencedContainer = "container:SZTextView.xcodeproj">
             </BuildableReference>

--- a/Demo/SZTextView/SZViewController.m
+++ b/Demo/SZTextView/SZViewController.m
@@ -14,11 +14,8 @@
 
 @implementation SZViewController
 
-- (void)viewDidLoad
-{
+- (void)viewDidLoad {
     [super viewDidLoad];
-
-    [[SZTextView appearance] setPlaceholderTextColor:[UIColor lightGrayColor]];
 
     CGFloat inset = 15.0;
     // ios 7
@@ -27,19 +24,6 @@
     } else {
         self.textView.contentInset = UIEdgeInsetsMake(inset, inset, inset, inset);
     }
-
-    self.textView.placeholder = @"Enter lorem ipsum here weofi ahöslfawoeö color. Dolor sit amet multiple.";
-    self.textView.font = [UIFont fontWithName:@"HelveticaNeue-Light" size:18.0];
 }
 
-- (void)didReceiveMemoryWarning
-{
-    [super didReceiveMemoryWarning];
-    // Dispose of any resources that can be recreated.
-}
-
-- (void)textViewDidChange:(UITextView *)textView
-{
-//    [textView resignFirstResponder];
-}
 @end

--- a/Demo/SZTextView/en.lproj/MainStoryboard.storyboard
+++ b/Demo/SZTextView/en.lproj/MainStoryboard.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="5056" systemVersion="13D65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" initialViewController="2">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="5056" systemVersion="13E28" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" initialViewController="2">
     <dependencies>
         <deployment version="1280" defaultVersion="1280" identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3733"/>
@@ -18,8 +18,14 @@
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                 <inset key="insetFor6xAndEarlier" minX="0.0" minY="20" maxX="0.0" maxY="0.0"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <fontDescription key="fontDescription" name="HelveticaNeue-Light" family="Helvetica Neue" pointSize="18"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="string" keyPath="placeholder" value="Enter lorem ipsum here weofi ahöslfawoeö color. Dolor sit amet multiple."/>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="placeholderTextColor">
+                                        <color key="value" white="0.0" alpha="0.5" colorSpace="deviceWhite"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
                             </textView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>

--- a/SZTextViewTests/SZTextViewStoryboardTests.m
+++ b/SZTextViewTests/SZTextViewStoryboardTests.m
@@ -1,0 +1,62 @@
+//
+//  SZTextViewTests.m
+//  SZTextViewTests
+//
+//  Created by glaszig on 14.03.13.
+//  Copyright (c) 2013 glaszig. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "SZTextView.h"
+
+@interface SZTextViewStoryboardTests : XCTestCase
+@end
+
+@interface SZTextViewStoryboardTests () {
+    SZTextView *textView;
+    UITextView *placeholderTextView;
+}
+@end
+
+@implementation SZTextViewStoryboardTests
+
+- (void)setUp
+{
+    [super setUp];
+    UIWindow *keyWindow = [UIApplication valueForKeyPath:@"sharedApplication.delegate.window"];
+    textView = [keyWindow.rootViewController valueForKey:@"textView"];
+    NSParameterAssert(textView);
+    placeholderTextView = [textView valueForKey:@"_placeholderTextView"];
+    NSParameterAssert(textView);
+}
+
+- (void)tearDown
+{
+    placeholderTextView = nil;
+    textView = nil;
+    [super tearDown];
+}
+
+- (void)testPlaceholderColor {
+    XCTAssertEqualObjects(placeholderTextView.textColor, [UIColor colorWithRed:0.0f
+                                                                         green:0.0f
+                                                                          blue:0.0f
+                                                                         alpha:0.5f], @"should be set in storyboard");
+}
+
+- (void)testPlaceholderText
+{
+    XCTAssertEqualObjects(placeholderTextView.text, @"Enter lorem ipsum here weofi ahöslfawoeö color. Dolor sit amet multiple.", @"should be set in storyboard");
+}
+
+- (void)testPlaceholderFont
+{
+    XCTAssertEqualObjects(placeholderTextView.font, textView.font, @"label and text view should have equal fonts");
+}
+
+- (void)testTextFont
+{
+    XCTAssertEqualObjects(textView.font, [UIFont fontWithName:@"HelveticaNeue-Light" size:18], @"should be set in storyboard");
+}
+
+@end


### PR DESCRIPTION
by setting placeholder text, color and font as user defined runtime attributes.
add test for SZTextView instantiated from the storyboard to verify runtime attributes of placeholder
