### PR TITLE
use copy instead of assign

### DIFF
--- a/Classes/SZTextView.m
+++ b/Classes/SZTextView.m
@@ -129,7 +129,7 @@ static NSString * const kTextContainerInsetKey = @"textContainerInset";
 - (void)setAttributedPlaceholder:(NSAttributedString *)attributedPlaceholderText
 {
     _placeholder = attributedPlaceholderText.string;
-    _attributedPlaceholder = attributedPlaceholderText;
+    _attributedPlaceholder = [attributedPlaceholderText copy];
 
     [self resizePlaceholderFrame];
 }


### PR DESCRIPTION
Should this be copy instead of plain assign? User can give you a `NSMutableAttributedString`.
