### PR TITLE
Use appropriate designated initializer on iOS 7 SDK and newer

### DIFF
--- a/Classes/SZTextView.m
+++ b/Classes/SZTextView.m
@@ -36,7 +36,7 @@ static NSString * const kTextAlignmentKey = @"textAlignment";
     return self;
 }
 
-#ifdef __IPHONE_7_0
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= 70000
 - (instancetype)initWithFrame:(CGRect)frame textContainer:(NSTextContainer *)textContainer
 {
     self = [super initWithFrame:frame textContainer:textContainer];


### PR DESCRIPTION
When compiling against iOS 7 SDK or newer, the designated initializer of UITextView (and SZTextView as its descendant) is `-initWithFrame:textContainer:`, not `-initWithFrame:`. In this case, `-initWithFrame:` just calls the designated initializer.
Currently though, only `-initWithFrame:` and `-initWithCoder:` initializers are provided in SZTextView, which also breaks if client code would like to use custom text container to initialize SZTextView (yep, it works).
Provided solution uses conditional macros to ensure that an appropriate designated initializer is used for each iOS SDK version (`NSTextContainer` is unavailable for SDKs older than 7.0, and having both initializers would result in both of them called when `-initWithFrame:` is used by client code).
