### PR TITLE
Fixed issue #21

### DIFF
--- a/Classes/SZTextView.m
+++ b/Classes/SZTextView.m
@@ -148,16 +148,6 @@ static NSString * const kTextAlignmentKey = @"textAlignment";
     [self resizePlaceholderFrame];
 }
 
-- (void)setContentInset:(UIEdgeInsets)contentInset{
-    [super setContentInset:contentInset];
-    self._placeholderTextView.contentInset = contentInset;
-}
-
--(void)setContentOffset:(CGPoint)contentOffset{
-    [super setContentOffset:contentOffset];
-    self._placeholderTextView.contentOffset = contentOffset;
-}
-
 - (void)layoutSubviews
 {
     [super layoutSubviews];


### PR DESCRIPTION
Sorry about this.  I realized my use case was ONLY if I had a SZTextView in a .xib.  If you have a SZTextView setup in a .xib and have a contentInset set, it needs to be set up right when initialized.  

Here is the issue I was having for reference. 
![ios simulator screen shot oct 13 2014 10 54 37 am](https://cloud.githubusercontent.com/assets/1844728/4618095/56b5f9a6-5306-11e4-82ef-7a33990ffa23.png)
