### PR TITLE
support IB_DESIGNABLE/IBInspectable

### DIFF
--- a/Classes/SZTextView.h
+++ b/Classes/SZTextView.h
@@ -8,6 +8,8 @@
 
 #import <UIKit/UIKit.h>
 
+IB_DESIGNABLE
+
 @interface SZTextView : UITextView
 
 @property (copy, nonatomic) IBInspectable NSString *placeholder;


### PR DESCRIPTION
implementing [xcode 6's new feature](https://developer.apple.com/library/ios/recipes/xcode_help-IB_objects_media/chapters/CreatingaLiveViewofaCustomObject.html#//apple_ref/doc/uid/TP40014224-CH41-SW1). works for `placeholder`. it's supposed to work with `UIColor` attributes as well but appears not to if the same attribute is marked `UI_APPEARANCE_SELECTOR`.