### PR TITLE
Add Framework Support

### DIFF
--- a/Classes/SZTextView.h
+++ b/Classes/SZTextView.h
@@ -8,6 +8,13 @@
 
 #import <UIKit/UIKit.h>
 
+//! Project version number for SZTextView.
+FOUNDATION_EXPORT double SZTextViewVersionNumber;
+
+//! Project version string for SZTextView.
+FOUNDATION_EXPORT const unsigned char SZTextViewVersionString[];
+
+
 IB_DESIGNABLE
 
 @interface SZTextView : UITextView

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://travis-ci.org/glaszig/SZTextView.svg?branch=master)](https://travis-ci.org/glaszig/SZTextView)
 [![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/glaszig/sztextview/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
+[![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 
 A drop-in UITextView replacement which gives you: a placeholder.  
 Technically it differs from other solutions in that it tries to work like UITextField's private `_placeholderLabel` so you should not suffer ugly glitches like jumping text views or loads of custom drawing code.
@@ -15,7 +16,23 @@ Your iOS project. (Tested on iOS versions 7.x, 8.0. Should also work on 5.x and 
 
 ## Installation
 
-Either clone this repo and add the project to your Xcode workspace or use [CocoaPods](http://cocoapods.org).
+Either clone this repo and add the project to your Xcode workspace, use [CocoaPods](http://cocoapods.org) or [Carthage](https://github.com/Carthage/Carthage).
+
+#### CocoaPods
+
+Add this to you Podfile:
+
+```ruby
+	pod 'SZTextView'
+```
+
+#### Carthage
+
+Add this line to your Cartfile:
+
+```
+	github "glaszig/SZTextView"
+```
 
 ## Usage
 

--- a/SZTextView.xcodeproj/project.pbxproj
+++ b/SZTextView.xcodeproj/project.pbxproj
@@ -1,0 +1,418 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		5B6530771AFB933B009D7775 /* SZTextView.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5B65306B1AFB933B009D7775 /* SZTextView.framework */; };
+		5B65307E1AFB933B009D7775 /* SZTextViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B65307D1AFB933B009D7775 /* SZTextViewTests.m */; };
+		5B6530891AFB938A009D7775 /* SZTextView.h in Headers */ = {isa = PBXBuildFile; fileRef = 5B6530871AFB938A009D7775 /* SZTextView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5B65308A1AFB938A009D7775 /* SZTextView.m in Sources */ = {isa = PBXBuildFile; fileRef = 5B6530881AFB938A009D7775 /* SZTextView.m */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		5B6530781AFB933B009D7775 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5B6530621AFB933B009D7775 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5B65306A1AFB933B009D7775;
+			remoteInfo = SZTextView;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		5B65306B1AFB933B009D7775 /* SZTextView.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SZTextView.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5B65306F1AFB933B009D7775 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		5B6530761AFB933B009D7775 /* SZTextViewTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SZTextViewTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		5B65307D1AFB933B009D7775 /* SZTextViewTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SZTextViewTests.m; sourceTree = "<group>"; };
+		5B6530871AFB938A009D7775 /* SZTextView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SZTextView.h; path = Classes/SZTextView.h; sourceTree = SOURCE_ROOT; };
+		5B6530881AFB938A009D7775 /* SZTextView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SZTextView.m; path = Classes/SZTextView.m; sourceTree = SOURCE_ROOT; };
+		5B65308B1AFB9441009D7775 /* SZTextViewTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "SZTextViewTests-Info.plist"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		5B6530671AFB933B009D7775 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5B6530731AFB933B009D7775 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5B6530771AFB933B009D7775 /* SZTextView.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		5B6530611AFB933B009D7775 = {
+			isa = PBXGroup;
+			children = (
+				5B65306D1AFB933B009D7775 /* SZTextView */,
+				5B65307A1AFB933B009D7775 /* SZTextViewTests */,
+				5B65306C1AFB933B009D7775 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		5B65306C1AFB933B009D7775 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				5B65306B1AFB933B009D7775 /* SZTextView.framework */,
+				5B6530761AFB933B009D7775 /* SZTextViewTests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		5B65306D1AFB933B009D7775 /* SZTextView */ = {
+			isa = PBXGroup;
+			children = (
+				5B6530871AFB938A009D7775 /* SZTextView.h */,
+				5B6530881AFB938A009D7775 /* SZTextView.m */,
+				5B65306E1AFB933B009D7775 /* Supporting Files */,
+			);
+			path = SZTextView;
+			sourceTree = "<group>";
+		};
+		5B65306E1AFB933B009D7775 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				5B65306F1AFB933B009D7775 /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		5B65307A1AFB933B009D7775 /* SZTextViewTests */ = {
+			isa = PBXGroup;
+			children = (
+				5B65307D1AFB933B009D7775 /* SZTextViewTests.m */,
+				5B65307B1AFB933B009D7775 /* Supporting Files */,
+			);
+			path = SZTextViewTests;
+			sourceTree = "<group>";
+		};
+		5B65307B1AFB933B009D7775 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				5B65308B1AFB9441009D7775 /* SZTextViewTests-Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		5B6530681AFB933B009D7775 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5B6530891AFB938A009D7775 /* SZTextView.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		5B65306A1AFB933B009D7775 /* SZTextView */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5B6530811AFB933B009D7775 /* Build configuration list for PBXNativeTarget "SZTextView" */;
+			buildPhases = (
+				5B6530661AFB933B009D7775 /* Sources */,
+				5B6530671AFB933B009D7775 /* Frameworks */,
+				5B6530681AFB933B009D7775 /* Headers */,
+				5B6530691AFB933B009D7775 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SZTextView;
+			productName = SZTextView;
+			productReference = 5B65306B1AFB933B009D7775 /* SZTextView.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		5B6530751AFB933B009D7775 /* SZTextViewTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5B6530841AFB933B009D7775 /* Build configuration list for PBXNativeTarget "SZTextViewTests" */;
+			buildPhases = (
+				5B6530721AFB933B009D7775 /* Sources */,
+				5B6530731AFB933B009D7775 /* Frameworks */,
+				5B6530741AFB933B009D7775 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				5B6530791AFB933B009D7775 /* PBXTargetDependency */,
+			);
+			name = SZTextViewTests;
+			productName = SZTextViewTests;
+			productReference = 5B6530761AFB933B009D7775 /* SZTextViewTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		5B6530621AFB933B009D7775 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0630;
+				TargetAttributes = {
+					5B65306A1AFB933B009D7775 = {
+						CreatedOnToolsVersion = 6.3.1;
+					};
+					5B6530751AFB933B009D7775 = {
+						CreatedOnToolsVersion = 6.3.1;
+					};
+				};
+			};
+			buildConfigurationList = 5B6530651AFB933B009D7775 /* Build configuration list for PBXProject "SZTextView" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 5B6530611AFB933B009D7775;
+			productRefGroup = 5B65306C1AFB933B009D7775 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				5B65306A1AFB933B009D7775 /* SZTextView */,
+				5B6530751AFB933B009D7775 /* SZTextViewTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		5B6530691AFB933B009D7775 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5B6530741AFB933B009D7775 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		5B6530661AFB933B009D7775 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5B65308A1AFB938A009D7775 /* SZTextView.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		5B6530721AFB933B009D7775 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5B65307E1AFB933B009D7775 /* SZTextViewTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		5B6530791AFB933B009D7775 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5B65306A1AFB933B009D7775 /* SZTextView */;
+			targetProxy = 5B6530781AFB933B009D7775 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		5B65307F1AFB933B009D7775 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		5B6530801AFB933B009D7775 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		5B6530821AFB933B009D7775 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = SZTextView/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = SZTextView;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		5B6530831AFB933B009D7775 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = SZTextView/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = SZTextView;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		5B6530851AFB933B009D7775 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = "SZTextViewTests/SZTextViewTests-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		5B6530861AFB933B009D7775 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = "SZTextViewTests/SZTextViewTests-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		5B6530651AFB933B009D7775 /* Build configuration list for PBXProject "SZTextView" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5B65307F1AFB933B009D7775 /* Debug */,
+				5B6530801AFB933B009D7775 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		5B6530811AFB933B009D7775 /* Build configuration list for PBXNativeTarget "SZTextView" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5B6530821AFB933B009D7775 /* Debug */,
+				5B6530831AFB933B009D7775 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		5B6530841AFB933B009D7775 /* Build configuration list for PBXNativeTarget "SZTextViewTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5B6530851AFB933B009D7775 /* Debug */,
+				5B6530861AFB933B009D7775 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 5B6530621AFB933B009D7775 /* Project object */;
+}

--- a/SZTextView.xcodeproj/xcshareddata/xcschemes/SZTextView.xcscheme
+++ b/SZTextView.xcodeproj/xcshareddata/xcschemes/SZTextView.xcscheme
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0630"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5B65306A1AFB933B009D7775"
+               BuildableName = "SZTextView.framework"
+               BlueprintName = "SZTextView"
+               ReferencedContainer = "container:SZTextView.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5B6530751AFB933B009D7775"
+               BuildableName = "SZTextViewTests.xctest"
+               BlueprintName = "SZTextViewTests"
+               ReferencedContainer = "container:SZTextView.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5B6530751AFB933B009D7775"
+               BuildableName = "SZTextViewTests.xctest"
+               BlueprintName = "SZTextViewTests"
+               ReferencedContainer = "container:SZTextView.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5B65306A1AFB933B009D7775"
+            BuildableName = "SZTextView.framework"
+            BlueprintName = "SZTextView"
+            ReferencedContainer = "container:SZTextView.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5B65306A1AFB933B009D7775"
+            BuildableName = "SZTextView.framework"
+            BlueprintName = "SZTextView"
+            ReferencedContainer = "container:SZTextView.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5B65306A1AFB933B009D7775"
+            BuildableName = "SZTextView.framework"
+            BlueprintName = "SZTextView"
+            ReferencedContainer = "container:SZTextView.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/SZTextView/Info.plist
+++ b/SZTextView/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.glaszig.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>


### PR DESCRIPTION
This PR adds support for frameworks. As a result, SZTextView can now be used with [Carthage](https://github.com/Carthage/Carthage).

`SZTextView.xcodeproj` has been created at the top level which builds the Framework. I have left the source files where they were so that the Podspec does not need to be updated.

I have tested with both, Cocoapods and Carthage and both ways of including SZTextView into my project have worked successfully.