### PR TITLE
Fixed auto layout loading failure bug

### DIFF
--- a/Classes/SZTextView.h
+++ b/Classes/SZTextView.h
@@ -14,9 +14,6 @@ FOUNDATION_EXPORT double SZTextViewVersionNumber;
 //! Project version string for SZTextView.
 FOUNDATION_EXPORT const unsigned char SZTextViewVersionString[];
 
-
-IB_DESIGNABLE
-
 @interface SZTextView : UITextView
 
 @property (copy, nonatomic) IBInspectable NSString *placeholder;


### PR DESCRIPTION
Removed IBDesignables from the component since it ain't working.
The following error would pop if using this component on IB using Auto Layout: `error: IB Designables: Failed to update auto layout status: Failed to load designables from path (null)`

That is now fixed.