### PR TITLE
Update SZTextView.podspec

### DIFF
--- a/SZTextView.podspec
+++ b/SZTextView.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.license        = 'MIT'
   s.author         = { 'glaszig' => 'glaszig@gmail.com' }
   s.source         = { :git => 'https://github.com/glaszig/SZTextView.git', :tag => s.version.to_s }
-  s.platform       = :ios, '8.0'
+  s.platform       = :ios, '9.0'
   s.source_files   = 'Classes/SZTextView.{h,m}'
   s.requires_arc   = true
 end


### PR DESCRIPTION
This updates the podspec to resolve  a warning with Xcode 12. 
<img width="451" alt="Screen Shot 2020-11-08 at 10 17 13 PM" src="https://user-images.githubusercontent.com/1163880/98496665-29245480-2210-11eb-848c-01f77cde08af.png">
